### PR TITLE
Codecov patch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,4 +43,5 @@ workflows:
       - node/test:
           name: upload-code-coverage
           post-steps:
-            - codecov/upload
+            - codecov/upload:
+                xtra_args: "--nonZero"


### PR DESCRIPTION
This PR adds option for codecov `uploader` to exit non-zero. This will change default behaviour and fail CircleCI `upload-code-coverage` job in case of codecov uploader  issues.